### PR TITLE
Fix weird behaviour with `CardSet::TheDarkinSaga`

### DIFF
--- a/src/data/deckcode/deck.rs
+++ b/src/data/deckcode/deck.rs
@@ -198,9 +198,7 @@ impl Deck {
         let card_count = reader.read_u32_varint().map_err(DeckDecodingError::Read)?;
 
         let set = reader.read_u32_varint().map_err(DeckDecodingError::Read)?;
-        let set = CardSet::from(set)
-            .to_code()
-            .ok_or(DeckDecodingError::UnknownSet)?;
+        let set = format!("{:02}", &set);
 
         let region = reader.read_u32_varint().map_err(DeckDecodingError::Read)?;
         let region = CardRegion::from(region)
@@ -229,8 +227,7 @@ impl Deck {
             .write_u32_varint(len)
             .map_err(DeckEncodingError::Write)?;
 
-        let set: u32 = CardSet::from_code(set)
-            .try_into()
+        let set: u32 = set.parse()
             .map_err(|_| DeckEncodingError::UnknownSet)?;
         writer
             .write_u32_varint(set)

--- a/src/data/setbundle/set.rs
+++ b/src/data/setbundle/set.rs
@@ -122,6 +122,7 @@ impl TryFrom<CardSet> for u32 {
             CardSet::EmpiresOfTheAscended => Ok(4),
             CardSet::BeyondTheBandlewood => Ok(5),
             CardSet::Worldwalker => Ok(6),
+            CardSet::TheDarkinSaga => Ok(6),
             _ => Err(()),
         }
     }

--- a/src/data/setbundle/set.rs
+++ b/src/data/setbundle/set.rs
@@ -84,6 +84,7 @@ impl CardSet {
             Self::EmpiresOfTheAscended => Some("04".to_string()),
             Self::BeyondTheBandlewood => Some("05".to_string()),
             Self::Worldwalker => Some("06".to_string()),
+            Self::TheDarkinSaga => Some("06".to_string()),
 
             _ => None,
         }

--- a/src/data/setbundle/set.rs
+++ b/src/data/setbundle/set.rs
@@ -55,8 +55,10 @@ impl CardSet {
         hm.get(self)
     }
 
-    /// Get the [`CardSet`] from its short code, **assuming it is not an [`CardSet::Events`] card**.
+    /// Get the [`CardSet`] from its short code.
     ///
+    /// [`CardSet::Worldwalker`] and [`CardSet::TheDarkinSaga`] share the same code `06`, so a variant cannot be determined.
+    /// 
     /// [`CardSet::Events`] cards have the short code of the set they were released in, so it is impossible to determine if a card belongs to that set from its short code.
     pub fn from_code(value: &str) -> Self {
         match value {

--- a/src/data/setbundle/set.rs
+++ b/src/data/setbundle/set.rs
@@ -94,6 +94,8 @@ impl CardSet {
 
 /// Get the [`CardSet`] from its internal id.
 ///
+/// [`CardSet::Worldwalker`] and [`CardSet::TheDarkinSaga`] share the same id, so a variant cannot be determined.
+/// 
 /// [`CardSet::Events`] cards have the id of the set they were released in, so it is impossible to determine if a card belongs to that set from its id.
 impl From<u32> for CardSet {
     fn from(value: u32) -> Self {

--- a/src/data/setbundle/set.rs
+++ b/src/data/setbundle/set.rs
@@ -65,7 +65,6 @@ impl CardSet {
             "03" => Self::CallOfTheMountain,
             "04" => Self::EmpiresOfTheAscended,
             "05" => Self::BeyondTheBandlewood,
-            "06" => Self::Worldwalker,
 
             _ => Self::Unsupported,
         }

--- a/src/data/setbundle/set.rs
+++ b/src/data/setbundle/set.rs
@@ -103,7 +103,6 @@ impl From<u32> for CardSet {
             3 => CardSet::CallOfTheMountain,
             4 => CardSet::EmpiresOfTheAscended,
             5 => CardSet::BeyondTheBandlewood,
-            6 => CardSet::Worldwalker,
             _ => CardSet::Unsupported,
         }
     }


### PR DESCRIPTION
It shares the same code as `CardSet::Worldwalker`, causing a few bugs here and there.