### PR TITLE
Run container as a non-privileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ COPY --from=builder \
     /usr/src/patched_porobot/target/*/release/patched_porobot_matrix \
     /usr/bin/
 
+USER ${UID}:${GID}
 ENTRYPOINT []
 CMD []
 


### PR DESCRIPTION
Uses the `USER` instruction.

See https://stackoverflow.com/questions/68155641/should-i-run-things-inside-a-docker-container-as-non-root-for-safety .